### PR TITLE
Use more standard angular formatting for factory

### DIFF
--- a/app/scripts/services/NodeClient.js
+++ b/app/scripts/services/NodeClient.js
@@ -1,5 +1,5 @@
-(function() {
-  function NodeClient() {
+angular.module('capstone', []).
+factory('NodeClient', function() {
     var Zendesk = require('zendesk-node-api');
 
     var NodeClient = {};
@@ -17,8 +17,5 @@
   }
 
   return NodeClient;
-};
-  angular
-    .module('capstone')
-    .factory('NodeClient', [NodeClient]);
-})();
+});
+


### PR DESCRIPTION
Not sure what the problem is, but I switched over to the more standard formatting for angular factories and modules (based on the docs) and the problem went away. sooo ¯\_(ツ)_/¯