### PR TITLE
begin upload file feature

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -25,6 +25,10 @@
   <script src="https://apis.google.com/js/platform.js" async defer></script>
   <!-- Angular Cookies -->
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.4/angular-cookies.js"></script>
+  <!-- Ng-file-upload -->
+  <!-- shim is needed to support non-HTML5 FormData browsers (IE8-9)-->
+  <script src="ng-file-upload-shim.min.js"></script>
+  <script src="ng-file-upload.min.js"></script>
   <!-- Application Files -->
   <script src="/scripts/app.js"></script>
   <script src="/scripts/services/GoogleOauth.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -26,6 +26,6 @@
   }
 
   angular
-    .module('capstone', ['ui.router', 'ui.bootstrap', 'ngCookies', 'ngRoute'])
+    .module('capstone', ['ui.router', 'ui.bootstrap', 'ngCookies', 'ngFileUpload', 'ngRoute'])
     .config(config);
 })();

--- a/app/scripts/services/ZenFactory.js
+++ b/app/scripts/services/ZenFactory.js
@@ -1,5 +1,5 @@
 (function() {
-  function ZenFactory($http, $cookies) {
+  function ZenFactory($http, $cookies, Upload) {
 
     var ZenFactory = {};
 
@@ -42,14 +42,17 @@
       });
     }
 
-    ZenFactory.createComment = function(userEmail, commentBody) {
+    ZenFactory.createComment = function(userEmail, commentBody, file) {
       var createComment = {
         method: 'POST',
         url: 'http://localhost:3000/api/tickets/new_comment',
         data: {
           user_email: userEmail,
           comment_body: commentBody,
-          id: $cookies.get('zendeskTicketId')
+          id: $cookies.get('zendeskTicketId'),
+          file: Upload.upload({
+            file
+          })
         }
       };
 
@@ -72,5 +75,5 @@
 
   angular
     .module('capstone')
-    .factory('ZenFactory', ['$http', '$cookies', ZenFactory]);
+    .factory('ZenFactory', ['$http', '$cookies', 'Upload', ZenFactory]);
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -341,6 +341,11 @@
       "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.3.tgz",
       "integrity": "sha1-uRCQcq03jCty9qAQHEPd+ys2ZB8="
     },
+    "ng-file-upload": {
+      "version": "12.2.13",
+      "resolved": "https://registry.npmjs.org/ng-file-upload/-/ng-file-upload-12.2.13.tgz",
+      "integrity": "sha1-AYAPOHLlJvlTEPhHfpnk8S0NjRQ="
+    },
     "nigel": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/nigel/-/nigel-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "angular-ui-router": "^0.4.2",
     "hapi": "~16.4.0",
     "inert": "^4.2.0",
+    "ng-file-upload": "^12.2.13",
     "path": "^0.4.9",
     "zendesk-node-api": "^1.2.0"
   },


### PR DESCRIPTION
Hey Ben, I'm working on allowing the user to upload a file with their comment and having some trouble injecting the `ng-file-upload` service. The docs for it can be found here: https://github.com/danialfarid/ng-file-upload#install

It all seems pretty straightforward, but I'm getting the following injector errors after I added it in:
![screen shot 2017-11-04 at 3 34 16 pm](https://user-images.githubusercontent.com/16979753/32410075-b3e6c084-c175-11e7-8f43-6f2ad1fab152.jpg)

I've been reviewing the installation and don't see anything off. The only difference I can see is that this service has what appears to be local paths for the script tags (`ng-file-upload.min.js`) whereas the others, such as Angular Cookies, are remote paths (`https...`). I don't think this would be the issue though considering the instructions name these script tags as the ones to be using. 